### PR TITLE
composer: dropped unnecessary Nette\Utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
   "require": {
     "php": ">= 7.1",
     "nette/di": "~2.4.13 || ~3.0.0",
-    "nette/utils": "~2.5.2 || ~3.0.0",
     "psr/container": "^1.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
Nette\Utils dependency is not used in the project at all.

This package and its constraint for Nette\Utils was blocking Nette\Utils v3.1.0 from installing for the rest of the ecosystem.